### PR TITLE
fix: remove fixedReason field

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -35,7 +35,6 @@ const query =
             dismissReason
             dismissComment
             fixedAt
-            fixReason
             dependencyScope
             repository{
               name
@@ -137,10 +136,6 @@ const query =
   {
     label: 'Fixed At',
     value: 'fixedAt'
-  },
-  {
-    label: 'Fix Reason',
-    value: 'fixReason'
   }
   ];
 


### PR DESCRIPTION
fixedReason is not an available field in the Github GraphQL API: https://docs.github.com/en/graphql/reference/objects#repositoryvulnerabilityalert

Runs of this action error out, currently.

This change removes that field.